### PR TITLE
Add bundle clean alias

### DIFF
--- a/modules/ruby/init.zsh
+++ b/modules/ruby/init.zsh
@@ -53,6 +53,7 @@ alias rb='ruby'
 # Bundler
 if (( $+commands[bundle] )); then
   alias rbb='bundle'
+  alias rbbc='bundle clean'
   alias rbbe='bundle exec'
   alias rbbi='bundle install --path vendor/bundle'
   alias rbbl='bundle list'


### PR DESCRIPTION
I propose `rbbc` alias for `bundle clean` command.
